### PR TITLE
- remove accordion

### DIFF
--- a/docs/_layouts/document.html
+++ b/docs/_layouts/document.html
@@ -18,12 +18,12 @@ layout: default
 
 <div class="oss docs main ui vertical segment">
   <div class="ui dividing left rail">
-    <div class="ui vertical following fluid accordion text menu">
+    <div class="ui vertical following fluid text menu">
       {% assign sorted_cats = site.categories | sort %}
       {% for category in sorted_cats %}
-      {% assign sorted_posts = category[1] | sort | reversed %}
-      <div class="item">
-        <a class="title active"><i class="dropdown icon"></i> <strong>{{ category[0] | capitalize }}</strong></a>
+      {% assign sorted_posts = category[1] | sort  %}
+      <div class="title">
+        {{ category[0] | capitalize }}
       </div>
       <div class="content menu">
         {% for post in sorted_posts %}

--- a/docs/_posts/2017-03-14-license.md
+++ b/docs/_posts/2017-03-14-license.md
@@ -5,6 +5,6 @@ date:   2017-03-14 14:35:52 -0500
 categories: Introduction
 ---
 
-# License
+## License
 
 Staple is licensed under the [GNU Lesser GPLv3](https://www.gnu.org/licenses/lgpl-3.0.en.html)

--- a/docs/_posts/2017-03-15-connection.md
+++ b/docs/_posts/2017-03-15-connection.md
@@ -5,12 +5,12 @@ date: 2017-03-15 17:32:04
 categories: Data
 ---
 
-# The Connection Class
+## The Connection Class
 
 The Connection class extends the PHP PDO objects to allow
 for various database connections.
 
-## Default Connection
+### Default Connection
 
 To initialize the default connection as specified by the `db`
 section of the `application.ini` or `application.php` file call:
@@ -22,7 +22,7 @@ $conn = Connection::get();
 Most query objects will call this method if a different connection
 object is not previously specified.
 
-### Named Connections
+#### Named Connections
 
 A named connection can be specified in the config file under
 any name that you would like. You can retrieve and establish
@@ -33,7 +33,7 @@ config attributes.
 $conn = Connection::getNamedConnection('myconn');
 ```
 
-### Queries
+#### Queries
 
 Execute a query against a database connection object.
 

--- a/docs/_posts/2017-03-15-query.md
+++ b/docs/_posts/2017-03-15-query.md
@@ -5,12 +5,12 @@ date: 2017-03-15 17:31:47
 categories: Data
 ---
 
-# The Query Class
+## The Query Class
 
 The `Query` class is quick query builder to simplify the process of writing
 queries.
 
-## Select Queries
+### Select Queries
 
 A basic select query.
 
@@ -27,7 +27,7 @@ SELECT * FROM customers;
 The `Query::select()` method also supports quick definitions of columns,
 db connection, order and limits.
 
-### Specify Columns
+#### Specify Columns
 
 To specify the columns to select, include the second method parameter as
 an array of the column names.
@@ -54,9 +54,9 @@ $query = Query::select('customers', ['FirstName'=>'given_name','email']);
 SELECT given_name AS FirstName, email FROM customers;
 ```
 
-## Where Clauses
+### Where Clauses
 
-### Where Equal
+#### Where Equal
 
 The `whereEqual(string $column, mixed $value)` method allows you to specify a column and a value to select on.
 
@@ -70,7 +70,7 @@ $query = Query::select('customers')->whereEqual('last_name','Smith');
 SELECT name, email FROM customers WHERE last_name = 'Smith';
 ```
 
-### Where In
+#### Where In
 
 The `whereIn(string $column, array|Query $value)` method allows you to pass a column name and then an array
 of values to filter by. You can also specify a subquery to pass to the `IN` clause.
@@ -84,7 +84,7 @@ $selectQuery = Query::select('referrals');
 $query = Query::select('customers')->whereIn('referral_id',$selectQuery);
 ```
 
-## Order By and Limits
+### Order By and Limits
 
 The fourth and fifth parameters allow for specification of order by and
 query limits.
@@ -106,8 +106,8 @@ SELECT name, email, city FROM customers ORDER BY name, city LIMIT 20;
 SELECT TOP 20 name, email, city FROM customers ORDER BY name, city;
 ```
 
-## Insert Queries
+### Insert Queries
 
-## Update Queries
+### Update Queries
 
-## Delete Queries
+### Delete Queries

--- a/docs/_sass/_code.scss
+++ b/docs/_sass/_code.scss
@@ -2,10 +2,10 @@
 p ,
 li {
   > code {
-    background: $grey-light;
-    color: darken($grey, 10%);
-    font-size: 90%;
-    padding: 0.1em 0.5em;
+    background: lighten(complement($masthead-background), 50%);
+    color: darken(complement($masthead-background), 10%);
+    font-size: 95%;
+    padding: 0.2em 0.5em;
     @include border-radius(3px);
   }
 }

--- a/docs/_sass/_docs.scss
+++ b/docs/_sass/_docs.scss
@@ -11,25 +11,33 @@
       }
     }
     .left.rail {
-      width: 20vw;
+      width: 18vw;
       padding-top: 3rem;
       .title {
         color: $masthead-background;
         font-size: 1.4em;
+        font-weight: bold;
+        &:before {
+          color: lighten($masthead-background, 40%);
+          content: '§';
+          margin-left: -2.4rem;
+          padding-right: 1.4rem;
+        }
       }
       .content {
         font-size: 1.2em;
       }
     }
     &.main.segment {
+      border-bottom: none !important;
       margin-top: 100px;
-      padding-left: 3rem;
-      padding-top: 3.5rem;
+      padding: 3rem;
       left: 33vw;
       width: 55vw;
+      min-height: 100%;
       h2, h3, h4, h5, h6 {
         &:before {
-          color: lighten($masthead-background, 30%);
+          color: lighten($masthead-background, 40%);
           content: '#';
           margin-left: -2.7rem;
           padding-right: 1.4rem;


### PR DESCRIPTION
- add section marker on docs menu
- new inline code styling based on complementary()
- removed all # (h1) tags in markdown; they should all semantically start with h2 based on the page header
- set docs col height min 100%