### PR TITLE
Insert Model Patch

### DIFF
--- a/library/Staple/Model.php
+++ b/library/Staple/Model.php
@@ -398,7 +398,7 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
 
 		//check for a new ID and apply it to the data set.
 		/** @var Insert $query */
-		if($query instanceof Insert)
+		if($query instanceof Insert && $result != false)
 			$this->_data[$this->_primaryKey] = $query->getInsertId();
 
 		//Return the boolean of success or failure.


### PR DESCRIPTION
When the insert results in an error, the model still attempts to retrieve the insert id. This causes a secondary error that covers the actual insert error.

This patch fixes the issue.