### PR TITLE
Fix an Error in the ModelSelectQuery Object

### DIFF
--- a/library/Staple/Model/ModelSelectQuery.php
+++ b/library/Staple/Model/ModelSelectQuery.php
@@ -117,7 +117,7 @@ class ModelSelectQuery extends ModelQuery implements ISelectQuery
 	 * @param bool $parameterized
 	 * @return ModelSelectQuery
 	 */
-	public function whereEqual($column, $value, bool $columnJoin = null, string $paramName = null, bool $parameterized = null)
+	public function whereEqual($column, $value, bool $columnJoin = null, string $paramName = null, bool $parameterized = true)
 	{
 		$this->queryObject->whereEqual($column, $value, $columnJoin, $paramName, $parameterized);
 		return $this;


### PR DESCRIPTION
Newer versions of PHP will not allow the assignment of null to a type-hinted parameter with a default of null. This fixes the error.